### PR TITLE
Group property management

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,11 @@ The configuration file is NSD-like as described below:
       algorithm: <string>
       secret: <base64 blob>
 
+If a group property is specified for a given zone (see [section 4.4.2](https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-dns-catalog-zones#section-4.4.2) of the RFC draft), this overrides the `pattern` option defined for the corresponding catalog zone. 
+
 ## zones2catz
 
-`zones2catz` creates a catalog zone from a text file containing one zone per line and writes its output to a file or _stdout_.
+`zones2catz` creates a catalog zone from a comma-separated text file containing one zone per line (and optionally the intended group for the zone) and writes its output to a file or _stdout_.
 
 ## References
 

--- a/dnscatz/catz2nsd.py
+++ b/dnscatz/catz2nsd.py
@@ -229,7 +229,7 @@ def get_catz_zones(catalog_zone: dns.zone.Zone) -> Dict:
                 raise CatalogZoneError("Broken catalog zone (group/TXT)")
             uuid = str(k).split(".")[1]
             group = str(rdataset[0]).strip("\"")
-            if not uuid in zones:
+            if uuid not in zones:
                 zones[uuid] = {}
             zones[uuid]['group'] = group
         elif str(k).startswith("coo."):
@@ -242,7 +242,7 @@ def get_catz_zones(catalog_zone: dns.zone.Zone) -> Dict:
                 raise CatalogZoneError("Broken catalog zone (PTR)")
             uuid = str(k).split(".")[0]
             zone = str(rdataset[0]).rstrip(".")
-            if not uuid in zones:
+            if uuid not in zones:
                 zones[uuid] = {}
             zones[uuid]['zone'] = zone
     return zones

--- a/dnscatz/catz2nsd.py
+++ b/dnscatz/catz2nsd.py
@@ -223,17 +223,17 @@ def get_catz_zones(catalog_zone: dns.zone.Zone) -> Set[str]:
                     raise CatalogZoneError(
                         f"Unsupported catalog zone version ({catz_version})"
                     )
-        elif str(k).endswith(".zones"):
-            rdataset = v.get_rdataset(dns.rdataclass.IN, dns.rdatatype.PTR)
-            if len(rdataset) != 1:
-                raise CatalogZoneError("Broken catalog zone (PTR)")
-            zones.add(str(rdataset[0]).rstrip("."))
         elif str(k).startswith("group."):
             logging.info("Group property not supported: %s", str(k))
         elif str(k).startswith("coo."):
             logging.info("Change of Ownership property not supported: %s", str(k))
         elif str(k).startswith("serial."):
             logging.info("Serial property not supported: %s", str(k))
+        elif str(k).endswith(".zones"):
+            rdataset = v.get_rdataset(dns.rdataclass.IN, dns.rdatatype.PTR)
+            if len(rdataset) != 1:
+                raise CatalogZoneError("Broken catalog zone (PTR)")
+            zones.add(str(rdataset[0]).rstrip("."))
     return zones
 
 

--- a/dnscatz/catz2nsd.py
+++ b/dnscatz/catz2nsd.py
@@ -225,9 +225,7 @@ def get_catz_zones(catalog_zone: dns.zone.Zone) -> Dict:
                     )
         elif str(k).startswith("group."):
             get_zone_property(
-                zones,
-                str(k),
-                v.get_rdataset(dns.rdataclass.IN, dns.rdatatype.TXT)
+                zones, str(k), v.get_rdataset(dns.rdataclass.IN, dns.rdatatype.TXT)
             )
         elif str(k).startswith("coo."):
             logging.info("Change of Ownership property not supported: %s", str(k))
@@ -235,18 +233,12 @@ def get_catz_zones(catalog_zone: dns.zone.Zone) -> Dict:
             logging.info("Serial property not supported: %s", str(k))
         elif str(k).endswith(".zones"):
             get_zone(
-                zones,
-                str(k),
-                v.get_rdataset(dns.rdataclass.IN, dns.rdatatype.PTR)
+                zones, str(k), v.get_rdataset(dns.rdataclass.IN, dns.rdatatype.PTR)
             )
     return zones
 
 
-def get_zone_property(
-    zones: Dict,
-    record: str,
-    rdataset: dns.rdataset.Rdataset
-):
+def get_zone_property(zones: Dict, record: str, rdataset: dns.rdataset.Rdataset):
     """Get zone property from correspindig TXT record"""
     zone_property = record.split(".")[0]
     uuid = record.split(".")[1]
@@ -254,21 +246,17 @@ def get_zone_property(
         raise CatalogZoneError("Broken catalog zone (%s/TXT)", zone_property)
     if uuid not in zones:
         zones[uuid] = {}
-    zones[uuid][zone_property] = str(rdataset[0]).strip("\"")
+    zones[uuid][zone_property] = str(rdataset[0]).strip('"')
 
 
-def get_zone(
-    zones: Dict,
-    record: str,
-    rdataset: dns.rdataset.Rdataset
-):
+def get_zone(zones: Dict, record: str, rdataset: dns.rdataset.Rdataset):
     """Get zone from PTR record"""
     uuid = record.split(".")[0]
     if len(rdataset) != 1:
         raise CatalogZoneError("Broken catalog zone (PTR)")
     if uuid not in zones:
         zones[uuid] = {}
-    zones[uuid]['zone'] = str(rdataset[0]).rstrip(".")
+    zones[uuid]["zone"] = str(rdataset[0]).rstrip(".")
 
 
 def get_catz_version(rr) -> Optional[int]:
@@ -354,9 +342,9 @@ def main() -> None:
 
     for cz in catalog_zones:
         for uuid in cz.zones:
-            zone = cz.zones[uuid]['zone']
-            if 'group' in cz.zones[uuid]:
-                group = cz.zones[uuid]['group']
+            zone = cz.zones[uuid]["zone"]
+            if "group" in cz.zones[uuid]:
+                group = cz.zones[uuid]["group"]
             else:
                 group = cz.pattern
             if zone not in current_zone_patterns:

--- a/dnscatz/catz2nsd.py
+++ b/dnscatz/catz2nsd.py
@@ -272,7 +272,7 @@ def ensure_unique_zones(catalog_zones: List[CatalogZone]):
     zone2catalogs = defaultdict(set)
     for cz in catalog_zones:
         for uuid in cz.zones:
-            zone = cz.zones[uuid]['zone']
+            zone = cz.zones[uuid]["zone"]
             zone2catalogs[zone].add(cz.origin)
     errors = 0
     for zone, catalogs in zone2catalogs.items():

--- a/dnscatz/zones2catz.py
+++ b/dnscatz/zones2catz.py
@@ -49,7 +49,7 @@ def generate_catalog_zone(origin: str, zonelist: str) -> str:
     print(f"{origin} {DEFAULT_TTL} IN NS invalid.")
     print(f'version.{origin} {DEFAULT_TTL} IN TXT "{CATZ_VERSION}"')
 
-    with open(zonelist, mode="r") as csv_file:
+    with open(str(zonelist), "r") as csv_file:
         csv_reader = csv.DictReader(csv_file, fieldnames=["zone", "group"])
         for row in csv_reader:
             zone = row["zone"].strip()
@@ -93,7 +93,7 @@ def main() -> None:
     if not origin.endswith("."):
         origin += "."
 
-    catalog_zone_str = generate_catalog_zone(origin=origin, zonelist=str(args.zonelist))
+    catalog_zone_str = generate_catalog_zone(origin=origin, zonelist=args.zonelist)
 
     if args.output:
         with open(args.output, "wt") as output_file:

--- a/dnscatz/zones2catz.py
+++ b/dnscatz/zones2catz.py
@@ -4,10 +4,10 @@ containing list of zones
 """
 
 import argparse
+import csv
 import sys
 import time
 import uuid
-import csv
 from io import StringIO
 
 CATZ_VERSION = 2
@@ -49,17 +49,17 @@ def generate_catalog_zone(origin: str, zonelist: str) -> str:
     print(f"{origin} {DEFAULT_TTL} IN NS invalid.")
     print(f'version.{origin} {DEFAULT_TTL} IN TXT "{CATZ_VERSION}"')
 
-    with open(zonelist, mode='r') as csv_file:
-        csv_reader = csv.DictReader(csv_file, fieldnames=['zone', 'group'])
+    with open(zonelist, mode="r") as csv_file:
+        csv_reader = csv.DictReader(csv_file, fieldnames=["zone", "group"])
         for row in csv_reader:
-            zone = row['zone'].strip()
+            zone = row["zone"].strip()
             if not zone.endswith("."):
                 zone += "."
             zone_id = uuid.uuid5(uuid.NAMESPACE_DNS, zone)
             print(f"{zone_id}.zones.{origin} {DEFAULT_TTL} IN PTR {zone}")
-            if row['group']:
-                group = row['group'].strip()
-                print(f"group.{zone_id}.zones.{origin} {DEFAULT_TTL} IN TXT \"{group}\"")
+            if row["group"]:
+                group = row["group"].strip()
+                print(f'group.{zone_id}.zones.{origin} {DEFAULT_TTL} IN TXT "{group}"')
 
     sys.stdout = old_stdout
 
@@ -93,7 +93,7 @@ def main() -> None:
     if not origin.endswith("."):
         origin += "."
 
-    catalog_zone_str = generate_catalog_zone(origin=origin, zonelist=args.zonelist)
+    catalog_zone_str = generate_catalog_zone(origin=origin, zonelist=str(args.zonelist))
 
     if args.output:
         with open(args.output, "wt") as output_file:


### PR DESCRIPTION
This implements management of the per-zone group property as defined in [section 4.4.2](https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-dns-catalog-zones#section-4.4.2) of the draft RFC:

* in `zones2catz` the list of zones can now be a comma-separated text file, where the zone-specific group can be passed as the second value of the line;
* in `catz2nsd`, the zone-specific group property is used instead of the catalog zone default if it is present. 